### PR TITLE
Vuex store returns function per 1.0.0-alpha changes

### DIFF
--- a/store/index.js
+++ b/store/index.js
@@ -4,7 +4,7 @@ import axios from 'axios'
 
 Vue.use(Vuex)
 
-const store = new Vuex.Store({
+const store = () => new Vuex.Store({
   state: {
     todos: []
   },


### PR DESCRIPTION
Fix of `Error: [nuxt] state should be a function in store/index.js` as
explained at https://github.com/nuxt/nuxt.js/issues/754